### PR TITLE
SPEED-393: Error handling

### DIFF
--- a/src/cliWizard.mjs
+++ b/src/cliWizard.mjs
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 
-import { cleanUp, downloadTemplatePackage, extractTemplatePackage, getArgv, getDirname, printLogo } from './utils.mjs';
+import { cleanUp, downloadTemplatePackage, extractTemplatePackage, getArgv, printLogo } from './utils.mjs';
 import { buildTemplateTask } from './buildTemplate.mjs';
 import { getConfigFromAnswers } from './config.mjs';
 import { defaultRules } from './defaults/rules.mjs';
@@ -17,6 +17,8 @@ const DEFAULT_TEMPLATE = '@salutejs/canvas-example';
 const checkboxInstructionsTranslation = `\n (Нажмите ${chalk.bold(
     chalk.cyan('<space>'),
 )} чтобы переключить функцию, ${chalk.bold(chalk.cyan('<enter>'))} чтобы завершить выбор)\n`;
+
+class RuntimeError extends Error {}
 
 export async function run() {
     try {
@@ -34,6 +36,10 @@ export async function run() {
 
         if (templatePath) {
             resolvedTemplatePath = path.resolve(templatePath);
+
+            if (!existsSync(path.resolve(resolvedTemplatePath))) {
+                throw new RuntimeError(`create-app: Invalid templatePath '${templatePath}': No such file or directory`);
+            }
         } else {
             const packageBuffer = await downloadTemplatePackage(templatePackage);
             resolvedTemplatePath = extractTemplatePackage(packageBuffer);
@@ -137,6 +143,12 @@ export async function run() {
         console.log(chalk.green('✅ Готово!'));
         console.log('');
     } catch (err) {
+        if (err instanceof RuntimeError) {
+            console.error(err.message);
+
+            return;
+        }
+
         console.error(err);
     } finally {
         cleanUp();


### PR DESCRIPTION
- handle invalid `templatePath` flag
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.12--canary.5.2605150885.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/create-app@0.1.12--canary.5.2605150885.0
  # or 
  yarn add @salutejs/create-app@0.1.12--canary.5.2605150885.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
